### PR TITLE
Close SSE connection when aborting client stream

### DIFF
--- a/web/src/app/chat/lib.tsx
+++ b/web/src/app/chat/lib.tsx
@@ -244,20 +244,23 @@ export async function* sendMessage({
     use_agentic_search: useLanggraph ?? false,
   });
 
+  const controller = new AbortController();
+  signal?.addEventListener("abort", () => controller.abort(), { once: true });
+
   const response = await fetch(`/api/chat/send-message`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body,
-    signal,
+    signal: controller.signal,
   });
 
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);
   }
 
-  yield* handleSSEStream<PacketType>(response, signal);
+  yield* handleSSEStream<PacketType>(response);
 }
 
 export async function nameChatSession(chatSessionId: string) {

--- a/web/src/lib/search/streamingUtils.ts
+++ b/web/src/lib/search/streamingUtils.ts
@@ -79,18 +79,11 @@ export async function* handleStream<T extends NonEmptyObject>(
 }
 
 export async function* handleSSEStream<T extends PacketType>(
-  streamingResponse: Response,
-  signal?: AbortSignal
+  streamingResponse: Response
 ): AsyncGenerator<T, void, unknown> {
   const reader = streamingResponse.body?.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
-  if (signal) {
-    signal.addEventListener("abort", () => {
-      console.log("aborting");
-      reader?.cancel();
-    });
-  }
   while (true) {
     const rawChunk = await reader?.read();
     if (!rawChunk) {


### PR DESCRIPTION
## Summary
- tie client abort signal to a new AbortController so the SSE fetch is properly terminated
- simplify `handleSSEStream` to rely on fetch abort instead of cancelling the reader

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beb884a588832599d5d8beb7b900a0